### PR TITLE
Added support for automatic conversion from the old Google OpenID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Google+ Sign-In for OSQA
 ========================
 
-OSQA Plugin that adds [Pure server-side flow for Google+ Sign-In](https://developers.google.com/+/web/signin/redirect-uri-flow).
+OSQA Plugin that adds [Pure server-side flow for Google+ Sign-In](https://developers.google.com/+/web/signin/redirect-uri-flow).  
+It also converts automatically existing accounts with the old Google OpenID credentials to the Google+ Sign-In without any data-loss.
 
 Installation
 ------------

--- a/gplusauth/authentication.py
+++ b/gplusauth/authentication.py
@@ -15,7 +15,6 @@ from forum.authentication.base import ConsumerTemplateContext
 from forum.authentication.base import InvalidAuthentication
 
 from forum.models.user import AuthKeyUserAssociation
-import django.core.exceptions
 
 CLIENT_SECRETS_PATH = os.path.join(django_settings.SITE_SRC_ROOT,
                                    'client_secrets.json')
@@ -101,7 +100,7 @@ class GooglePlusAuthConsumer(AuthenticationConsumer):
             try:
                 old = AuthKeyUserAssociation.objects.get(key=openid,
                                                          provider="google")
-            except django.core.exceptions.DoesNotExist:
+            except AuthKeyUserAssociation.DoesNotExist:
                 pass
             else:
                 old.key = assoc_key

--- a/gplusauth/authentication.py
+++ b/gplusauth/authentication.py
@@ -14,6 +14,9 @@ from forum.authentication.base import AuthenticationConsumer
 from forum.authentication.base import ConsumerTemplateContext
 from forum.authentication.base import InvalidAuthentication
 
+from forum.models.user import AuthKeyUserAssociation
+import django.core.exceptions
+
 CLIENT_SECRETS_PATH = os.path.join(django_settings.SITE_SRC_ROOT,
                                    'client_secrets.json')
 CLIENT_SECRETS = json.loads(open(CLIENT_SECRETS_PATH, 'r').read())
@@ -51,6 +54,13 @@ class GooglePlusAuthConsumer(AuthenticationConsumer):
             client_id=CLIENT_ID,
             access_type="offline"
         )
+
+        # Send also openid.realm to get the necessary data to convert from the
+        # old OpenID to Google+
+        realm = getattr(django_settings, 'OPENID_TRUST_ROOT',
+                        django_settings.APP_URL+'/')
+        request_data["openid.realm"] = realm
+
         login_url = 'https://accounts.google.com/o/oauth2/auth?{0}'.format(
             urllib.urlencode(request_data)
         )
@@ -81,6 +91,23 @@ class GooglePlusAuthConsumer(AuthenticationConsumer):
         assoc_key = credentials.id_token['sub']
         request.session["access_token"] = access_token
         request.session["assoc_key"] = assoc_key
+
+        # Convert old Google OpenID to Google+
+        openid = credentials.id_token['openid_id']
+        already_existing = AuthKeyUserAssociation.objects.filter(
+            key=assoc_key, provider="googleplus"
+        )
+        if already_existing.count() == 0:
+            try:
+                old = AuthKeyUserAssociation.objects.get(key=openid,
+                                                         provider="google")
+            except django.core.exceptions.DoesNotExist:
+                pass
+            else:
+                old.key = assoc_key
+                old.provider = "googleplus"
+                old.save()
+
         return assoc_key
 
     def get_user_data(self, assoc_key):


### PR DESCRIPTION
This change, during the OAuth request, requests to Google also the old OpenID the user had for the current website. Then, during the response processing, if the ``assoc_key`` isn't present in the database and an user has the same OpenID key Google sent to the website during the response (and so it's the same user, from the Google point of view), it replace the old OpenID token with the new token sent from Google.

All the process is completly transparent, and if you replace the old OpenID button with the Google+ one, users won't notice any difference, except if they explicitly want to see their authentication methods.