### PR TITLE
Remove migration from OpenID to OAuth2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 Google+ Sign-In for OSQA
 ========================
 
-OSQA Plugin that adds [Pure server-side flow for Google+ Sign-In](https://developers.google.com/+/web/signin/redirect-uri-flow).  
-It also converts automatically existing accounts with the old Google OpenID credentials to the Google+ Sign-In without any data-loss.
+OSQA Plugin that adds [Pure server-side flow for Google+ Sign-In](https://developers.google.com/+/web/signin/redirect-uri-flow).
 
 Installation
 ------------


### PR DESCRIPTION
Google removed support for the migration process between OpenID and OAuth2 on January 1st, 2017.
This removes the migration code, which is crashing.

[Removal notice](https://developers.google.com/identity/sign-in/auth-migration) (in the timetable).

This reverts commit 29d00ddd1c23d327081d0abcdd8edf963949f69e.
This reverts commit 89074c133bce26dfce26c2c7cdc48c833cf3fbf6.